### PR TITLE
Non-angular ESLint reporter and ability to send custom linter wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,12 @@ All params for launchReporters are optional, if you dont pass them, they'll skip
 
 Since not all project will match the default values, you can customize it, each reporter has params :
 
-* src : the gulp.src params to use for the task, probably the only one you'll have to override
-* report : the report json file path to use
-* rulesFile : the rules file to use
-* task : the gulp task name to use for the report
-* base : (for eslint only) the base folder for seeking sources
+* src: the gulp.src params to use for the task, probably the only one you'll have to override
+* report: the report json file path to use
+* rulesFile: the rules file to use
+* task: the gulp task name to use for the report
+* base: (for eslint only) the base folder for seeking sources
+* linter: the gulp linter wrapper to use for the report
 
 # Default values
 
@@ -61,48 +62,55 @@ gulp.task('lint', function() {
           src: "src/**/*.css",
           report: "reports/sonar/csslint.json",
           rulesFile: ".csslintrc",
-          task: "ci-csslint"
+          task: "ci-csslint",
+          linter: require("gulp-csslint")
         },
         scss: {
           src: "src/**/*.scss",
           report: "reports/sonar/scsslint.json",
           rulesFile: ".scsslintrc",
-          task: "ci-scsslint"
+          task: "ci-scsslint",
+          linter: require("gulp-scss-lint")
         },
         html: {
           src: "src/**/*.html",
           report: "reports/sonar/htmlhint.json",
           rulesFile: ".htmlhintrc",
-          task: "ci-htmlhint"
+          task: "ci-htmlhint",
+          linter: require("gulp-htmlhint")
         },
         js: {
           src: "src/**/*.js",
           report: "reports/sonar/jshint.json",
           rulesFile: ".jshintrc",
-          task: "ci-jshint"
+          task: "ci-jshint",
+          linter: require("gulp-jshint")
         },
         eslint: {
           src: "src/**/*.js",
           report: "reports/sonar/eslint.json",
           rulesFile: ".eslintrc",
           task: "ci-eslint",
-          base: "src"
+          base: "src",
+          linter: require("gulp-eslint")
         },
         eslint_angular: {
           src: "src/**/*.js",
           report: "reports/sonar/eslint-angular.json",
           rulesFile: ".eslintrc",
           task: "ci-eslint-angular",
-          base: "src"
+          base: "src",
+          linter: require("gulp-eslint")
         },
         ts: {
           src: "src/**/*.ts",
           report: "reports/sonar/tslint.json",
           rulesFile: "tslint.json",
-          task: "ci-tslint"
+          task: "ci-tslint",
+          linter: require("gulp-tslint")
         },
         callback: function() {
-          console.log('Linting ended !');
+          console.log('Linting ended!');
         }
     });
 });

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# sonar-wed-frontend-reporters
+# sonar-web-frontend-reporters
 
 [![NPM version][npm-image]][npm-url]
 
@@ -7,12 +7,14 @@
 
 This is a repo for SII continuous integration build system dedicated to Front-end webapps. This repo provides all the linters reporters written by SII for the generic [Sonarqube plugin](https://github.com/groupe-sii/sonar-web-client-plugin). Usage is based on gulp.
 
-#Getting started
+# Getting started
+
 ```bash
 npm i --save-dev sonar-web-frontend-reporters
 ```
 
-#Default Usage
+# Default Usage
+
 ```Javascript
 'use strict';
 var gulp = require('gulp'),
@@ -22,20 +24,25 @@ var gulp = require('gulp'),
 gulp.task('lint', function() {
     return SonarWebReporters.launchReporters({
         project: projectName, //your project's name
-        css : true,//activate css linter with default values
-        scss : true,//activate scss linter with default values
-        html : true,//activate html linter with default values
-        js : true,//activate js linter with default values
-        eslint : true,//activate eslint for angular linter with default values
-        ts : true//activate tslint with default values
+        css: true, //activate CSS Lint with default values
+        scss: true, //activate SCSS Lint with default values
+        html: true, //activate HTMLHint with default values
+        js: true, //activate JSHint with default values
+        eslint: true, //activate ESLint with default values
+        eslint_angular: true, //activate ESLint for Angular with default values
+        ts: true //activate TSLint with default values
     });
 });
 ```
+
 ```bash
 gulp lint
 ```
+
 All params for launchReporters are optional, if you dont pass them, they'll skip linters. We rarely need to scan both css and scss for example.
-#Configuration
+
+# Configuration
+
 Since not all project will match the default values, you can customize it, each reporter has params :
 
 * src : the gulp.src params to use for the task, probably the only one you'll have to override
@@ -44,47 +51,55 @@ Since not all project will match the default values, you can customize it, each 
 * task : the gulp task name to use for the report
 * base : (for eslint only) the base folder for seeking sources
 
-##Default values
+# Default values
+
 ```Javascript
 gulp.task('lint', function() {
     return SonarWebReporters.launchReporters({
         project: projectName,
-        css : {
-          src : "src/**/*.css",
-          report : "reports/sonar/csslint.json",
-          rulesFile : ".csslintrc",
-          task : "ci-csslint"
+        css: {
+          src: "src/**/*.css",
+          report: "reports/sonar/csslint.json",
+          rulesFile: ".csslintrc",
+          task: "ci-csslint"
         },
-        scss : {
-          src : "src/**/*.scss",
-          report : "reports/sonar/scsslint.json",
-          rulesFile : ".scsslintrc",
-          task : "ci-scsslint"
+        scss: {
+          src: "src/**/*.scss",
+          report: "reports/sonar/scsslint.json",
+          rulesFile: ".scsslintrc",
+          task: "ci-scsslint"
         },
-        html : {
-          src : "src/**/*.html",
-          report : "reports/sonar/htmlhint.json",
-          rulesFile : ".htmlhintrc",
-          task : "ci-htmlhint"
+        html: {
+          src: "src/**/*.html",
+          report: "reports/sonar/htmlhint.json",
+          rulesFile: ".htmlhintrc",
+          task: "ci-htmlhint"
         },
-        js : {
-          src : "src/**/*.js",
-          report : "reports/sonar/jshint.json",
-          rulesFile : ".jshintrc",
-          task : "ci-jshint"
+        js: {
+          src: "src/**/*.js",
+          report: "reports/sonar/jshint.json",
+          rulesFile: ".jshintrc",
+          task: "ci-jshint"
         },
-        eslint : {
-          src : "src/**/*.js",
-          report : "reports/sonar/eslint-angular.json",
-          rulesFile : ".eslintrc",
-          task : "ci-eslint",
-          base : "src"
+        eslint: {
+          src: "src/**/*.js",
+          report: "reports/sonar/eslint.json",
+          rulesFile: ".eslintrc",
+          task: "ci-eslint",
+          base: "src"
         },
-        ts : {
-          src : "src/**/*.ts",
-          report : "reports/sonar/tslint.json",
-          rulesFile : "tslint.json",
-          task : "ci-tslint"
+        eslint_angular: {
+          src: "src/**/*.js",
+          report: "reports/sonar/eslint-angular.json",
+          rulesFile: ".eslintrc",
+          task: "ci-eslint-angular",
+          base: "src"
+        },
+        ts: {
+          src: "src/**/*.ts",
+          report: "reports/sonar/tslint.json",
+          rulesFile: "tslint.json",
+          task: "ci-tslint"
         },
         callback: function() {
           console.log('Linting ended !');
@@ -93,15 +108,16 @@ gulp.task('lint', function() {
 });
 ```
 
-#Sample project with jasmine/istanbul for testing
+# Sample project with jasmine/istanbul for testing
 
 SOON
 
-#Sample project with intern for testing
+# Sample project with intern for testing
 
-An example project is available here : https://github.com/groupe-sii/sonar-web-frontend-helloworld
+An example project is available here: https://github.com/groupe-sii/sonar-web-frontend-helloworld
 
 # Informations for Sonarqube
+
 The export files for Sonarqube are JSON files providing all informations a Sonarqube issue might need :
 
 * Project Description
@@ -134,17 +150,20 @@ The export files for Sonarqube are JSON files providing all informations a Sonar
   * creationDate : Date of issue creation
 
 # Included Reporters
+
 Reporters are custom reporters written for the gulp tasks of each linter, the output is a Sonarqube compatible JSON file.
 A Reporter must be open before being passed to linter/hinter plugin, and closed after the linter/hinter plugin ended its task.
 
-* [HTMLhint](http://htmlhint.com/)
-* [JShint](http://jshint.com/)
-* [CSSlint](http://csslint.net/)
-* [SCSSLint](https://github.com/brigade/scss-lint)
-* [ESLint angular](https://github.com/Gillespie59/eslint-plugin-angular)
+* [HTMLHint](http://htmlhint.com/)
+* [JSHint](http://jshint.com/)
+* [CSS Lint](http://csslint.net/)
+* [SCSS Lint](https://github.com/brigade/scss-lint)
+* [ESLint](http://eslint.org/)
+* [ESLint for Angular](https://github.com/Gillespie59/eslint-plugin-angular)
 * [TSLint](http://palantir.github.io/tslint/)
 
-#Roadmap
+# Roadmap
+
 New reporters will be added over time, with new webtechnologies incoming :
 
 * Angular2 linter / Codelyzer

--- a/esLintAngularReporter.js
+++ b/esLintAngularReporter.js
@@ -8,15 +8,15 @@ var Model = require('./reporterModel'),
 
     BASE_PROJECT = path.normalize(__dirname.substring(0, __dirname.indexOf('/node_')+1));
 
-function ESLintReporter(reportFile, base) {
+function ESLintAngularReporter(reportFile, base) {
     Model.call(this, reportFile);
     global.selfESR = this;
     global.selfESR.base = BASE_PROJECT + base + path.sep;
 }
 
-inherits(ESLintReporter, Model);
+inherits(ESLintAngularReporter, Model);
 
-ESLintReporter.prototype.reporter = function(results) {
+ESLintAngularReporter.prototype.reporter = function(results) {
 
     var readFile = function(file) {
         var _d = q.defer();
@@ -65,10 +65,11 @@ ESLintReporter.prototype.reporter = function(results) {
                         fileNbViolations[global.selfESR.INFO]++;
                         break;
                 }
+                ruleId = message.ruleId.replace('angular/', '');
                 fs.appendFileSync(global.selfESR.reportFile, '{\n\t\t"line" : ' + message.line + ',\n\t\t' +
                     '"message" : "' + message.message.replace(/["']/g, '\'') + '",\n\t\t' +
                     '"description" : "",\n\t\t' +
-                    '"rulekey" : "' + message.ruleId + '",\n\t\t' +
+                    '"rulekey" : "ng_' + ruleId.replace(/-/g, '_') + '",\n\t\t' +
                     '"severity" : "' + severity + '",\n\t\t' +
                     '"reporter" : "eslint",\n\t\t' +
                     '"creationDate" : ' + d + '\n\t\t' + ((index < errorCount - 1) ? '},' : '}'));
@@ -88,4 +89,4 @@ ESLintReporter.prototype.reporter = function(results) {
     loop();
 
 };
-module.exports = ESLintReporter;
+module.exports = ESLintAngularReporter;

--- a/sonarWebReporters.js
+++ b/sonarWebReporters.js
@@ -24,7 +24,7 @@ function SonarWebReporters() {
     this.launchReporters = function (options) {
         var tasks = [], projectName = options.project || options.projectName || "";
         if (options.css) {
-            var csslint = require('gulp-csslint'),
+            var csslint = options.css.linter || require('gulp-csslint'),
                 cssSources = options.css.src || options.css.sources || "src/**/*.css",
                 cssPath = options.css.report || "reports/sonar/csslint.json",
                 cssTask = options.css.task || "ci-csslint",
@@ -42,7 +42,7 @@ function SonarWebReporters() {
         }
 
         if (options.scss) {
-            var scsslint = require('gulp-scss-lint'),
+            var scsslint = options.scss.linter || require('gulp-scss-lint'),
                 scssSources = options.scss.src || options.scss.sources || "src/**/*.scss",
                 scssPath = options.scss.report || "reports/sonar/scsslint.json",
                 scssTask = options.scss.task || "ci-scsslint",
@@ -62,7 +62,7 @@ function SonarWebReporters() {
         }
 
         if (options.html) {
-            var htmlhint = require('gulp-htmlhint'),
+            var htmlhint = options.html.linter || require('gulp-htmlhint'),
                 htmlSources = options.html.src || options.html.sources || "src/**/*.html",
                 htmlPath = options.html.report || "reports/sonar/htmlhint.json",
                 htmlTask = options.html.task || "ci-htmlhint",
@@ -82,7 +82,7 @@ function SonarWebReporters() {
         }
 
         if (options.js) {
-            var jshint = require('gulp-jshint'),
+            var jshint = options.js.linter || require('gulp-jshint'),
                 jsSources = options.js.src || options.js.sources || "src/**/*.js",
                 jsPath = options.js.report || "reports/sonar/jshint.json",
                 jsTask = options.js.task || "ci-jshint",
@@ -106,7 +106,7 @@ function SonarWebReporters() {
         }
 
         if (options.eslint_angular) {
-            var eslint = require('gulp-eslint'),
+            var eslint = options.eslint_angular.linter || require('gulp-eslint'),
                 eslintAngularSources = options.eslint_angular.src || options.eslint_angular.sources || "src/**/*.js",
                 eslintAngularPath = options.eslint_angular.report || "reports/sonar/eslint-angular.json",
                 eslintAngularTask = options.eslint_angular.task || "ci-eslint-angular",
@@ -127,7 +127,7 @@ function SonarWebReporters() {
         }
 
         if (options.eslint) {
-            var eslint = require('gulp-eslint'),
+            var eslint = options.eslint.linter || require('gulp-eslint'),
                 eslintSources = options.eslint.src || options.eslint.sources || "src/**/*.js",
                 eslintPath = options.eslint.report || "reports/sonar/eslint.json",
                 eslintTask = options.eslint.task || "ci-eslint",
@@ -148,7 +148,7 @@ function SonarWebReporters() {
         }
 
         if (options.ts) {
-            var tslint = require('gulp-tslint'),
+            var tslint = options.ts.linter || require('gulp-tslint'),
                 tsSources = options.ts.src || options.ts.sources || "src/**/*.ts",
                 tsPath = options.ts.report || "reports/sonar/tslint.json",
                 tsTask = options.ts.task || "ci-tslint",

--- a/sonarWebReporters.js
+++ b/sonarWebReporters.js
@@ -112,7 +112,7 @@ function SonarWebReporters() {
                 eslintAngularTask = options.eslint_angular.task || "ci-eslint-angular",
                 eslintAngularBase = options.eslint_angular.base || "src",
                 eslintAngularReporter = new this.ESAngularReporter(eslintAngularPath, eslintAngularBase);
-            createReportPath(eslintAngularTask);
+            createReportPath(eslintAngularPath);
 
             gulp.task(eslintAngularTask, function () {
                 eslintAngularReporter.openReporter(projectName, eslintAngularPath);
@@ -133,7 +133,7 @@ function SonarWebReporters() {
                 eslintTask = options.eslint.task || "ci-eslint",
                 eslintBase = options.eslint.base || "src",
                 eslintReporter = new this.ESReporter(eslintPath, eslintBase);
-            createReportPath(eslintTask);
+            createReportPath(eslintPath);
 
             gulp.task(eslintTask, function () {
                 eslintReporter.openReporter(projectName, eslintPath);

--- a/sonarWebReporters.js
+++ b/sonarWebReporters.js
@@ -1,163 +1,185 @@
 'use strict';
 
 var gulp = require('gulp'),
-		mkdirp = require('mkdirp'),
-		fs = require('fs-extra'),
-		run = require('run-sequence');
+    mkdirp = require('mkdirp'),
+    fs = require('fs-extra'),
+    run = require('run-sequence');
 
-function createReportPath(reportPath){
-	var path = reportPath.substring(0,reportPath.lastIndexOf("/"));
-	if (!fs.existsSync(path)){
-		mkdirp.sync(path);
-	}
+function createReportPath(reportPath) {
+    var path = reportPath.substring(0, reportPath.lastIndexOf("/"));
+    if (!fs.existsSync(path)) {
+        mkdirp.sync(path);
+    }
 }
 
 function SonarWebReporters() {
-		this.SCSSReporter = require('./scssReporter.js');
-		this.JSReporter = require('./jsReporter.js');
-		this.ESReporter = require('./esLintReporter.js');
-		this.HTMLReporter = require('./htmlReporter.js');
-		this.CSSReporter = require('./cssReporter.js');
-		this.TSLINTReporter = require('./tslintReporter.js');
+    this.SCSSReporter = require('./scssReporter.js');
+    this.JSReporter = require('./jsReporter.js');
+    this.ESReporter = require('./esLintReporter.js');
+    this.ESAngularReporter = require('./esLintAngularReporter.js');
+    this.HTMLReporter = require('./htmlReporter.js');
+    this.CSSReporter = require('./cssReporter.js');
+    this.TSLINTReporter = require('./tslintReporter.js');
 
-		this.launchReporters = function(options){
-			var tasks = [], projectName = options.project || options.projectName || "";
-			if (options.css){
-				var csslint = require('gulp-csslint'),
-					cssSources = options.css.src || options.css.sources || "src/**/*.css",
-					cssPath = options.css.report || "reports/sonar/csslint.json",
-					cssTask = options.css.task || "ci-csslint",
-					cssReporter = new this.CSSReporter(cssPath);
-					createReportPath(cssPath);
+    this.launchReporters = function (options) {
+        var tasks = [], projectName = options.project || options.projectName || "";
+        if (options.css) {
+            var csslint = require('gulp-csslint'),
+                cssSources = options.css.src || options.css.sources || "src/**/*.css",
+                cssPath = options.css.report || "reports/sonar/csslint.json",
+                cssTask = options.css.task || "ci-csslint",
+                cssReporter = new this.CSSReporter(cssPath);
+            createReportPath(cssPath);
 
-					gulp.task(cssTask, function() {
-							cssReporter.openReporter(projectName, cssPath);
-							return gulp.src(cssSources)
-									.pipe(csslint(options.css.rulesFile))
-									.pipe(csslint.reporter(cssReporter.reporter.bind(cssReporter)))
-									.on('end', cssReporter.closeReporter.bind(cssReporter));
-					});
-					tasks.push(cssTask);
-			}
+            gulp.task(cssTask, function () {
+                cssReporter.openReporter(projectName, cssPath);
+                return gulp.src(cssSources)
+                    .pipe(csslint(options.css.rulesFile))
+                    .pipe(csslint.reporter(cssReporter.reporter.bind(cssReporter)))
+                    .on('end', cssReporter.closeReporter.bind(cssReporter));
+            });
+            tasks.push(cssTask);
+        }
 
-			if (options.scss){
-				var scsslint = require('gulp-scss-lint'),
-					scssSources = options.scss.src || options.scss.sources || "src/**/*.scss",
-					scssPath = options.scss.report || "reports/sonar/scsslint.json",
-					scssTask = options.scss.task || "ci-scsslint",
-					scssReporter = new this.SCSSReporter(scssPath);
-					createReportPath(scssPath);
+        if (options.scss) {
+            var scsslint = require('gulp-scss-lint'),
+                scssSources = options.scss.src || options.scss.sources || "src/**/*.scss",
+                scssPath = options.scss.report || "reports/sonar/scsslint.json",
+                scssTask = options.scss.task || "ci-scsslint",
+                scssReporter = new this.SCSSReporter(scssPath);
+            createReportPath(scssPath);
 
-					gulp.task(scssTask, function() {
-							scssReporter.openReporter(projectName, scssPath);
-							return gulp.src(scssSources)
-									.pipe(scsslint({
-										customReport: scssReporter.reporter.bind(scssReporter),
-										config: options.scss.rulesFile || null
-									}))
-									.on('end', scssReporter.closeReporter.bind(scssReporter));
-					});
-					tasks.push(scssTask);
-			}
+            gulp.task(scssTask, function () {
+                scssReporter.openReporter(projectName, scssPath);
+                return gulp.src(scssSources)
+                    .pipe(scsslint({
+                        customReport: scssReporter.reporter.bind(scssReporter),
+                        config: options.scss.rulesFile || null
+                    }))
+                    .on('end', scssReporter.closeReporter.bind(scssReporter));
+            });
+            tasks.push(scssTask);
+        }
 
-			if (options.html){
-				var htmlhint = require('gulp-htmlhint'),
-					htmlSources = options.html.src || options.html.sources || "src/**/*.html",
-					htmlPath = options.html.report || "reports/sonar/htmlhint.json",
-					htmlTask = options.html.task || "ci-htmlhint",
-					htmlReporter = new this.HTMLReporter(htmlPath);
-					createReportPath(htmlPath);
+        if (options.html) {
+            var htmlhint = require('gulp-htmlhint'),
+                htmlSources = options.html.src || options.html.sources || "src/**/*.html",
+                htmlPath = options.html.report || "reports/sonar/htmlhint.json",
+                htmlTask = options.html.task || "ci-htmlhint",
+                htmlReporter = new this.HTMLReporter(htmlPath);
+            createReportPath(htmlPath);
 
-					gulp.task(htmlTask, function() {
-							htmlReporter.openReporter(projectName, htmlPath);
-							return gulp.src(htmlSources)
-									.pipe(htmlhint({
-										htmlhintrc: options.html.rulesFile || null
-									}))
-									.pipe(htmlhint.reporter(htmlReporter.reporter.bind(htmlReporter)))
-									.on('end', htmlReporter.closeReporter.bind(htmlReporter));
-					});
-					tasks.push(htmlTask);
-			}
+            gulp.task(htmlTask, function () {
+                htmlReporter.openReporter(projectName, htmlPath);
+                return gulp.src(htmlSources)
+                    .pipe(htmlhint({
+                        htmlhintrc: options.html.rulesFile || null
+                    }))
+                    .pipe(htmlhint.reporter(htmlReporter.reporter.bind(htmlReporter)))
+                    .on('end', htmlReporter.closeReporter.bind(htmlReporter));
+            });
+            tasks.push(htmlTask);
+        }
 
-			if (options.js){
-				var jshint = require('gulp-jshint'),
-					jsSources = options.js.src || options.js.sources || "src/**/*.js",
-					jsPath = options.js.report || "reports/sonar/jshint.json",
-					jsTask = options.js.task || "ci-jshint",
-					jsReporter = new this.JSReporter(jsPath),
-					jshintConfig = {};
-					createReportPath(jsPath);
+        if (options.js) {
+            var jshint = require('gulp-jshint'),
+                jsSources = options.js.src || options.js.sources || "src/**/*.js",
+                jsPath = options.js.report || "reports/sonar/jshint.json",
+                jsTask = options.js.task || "ci-jshint",
+                jsReporter = new this.JSReporter(jsPath),
+                jshintConfig = {};
+            createReportPath(jsPath);
 
-					if(options.js.rulesFile) {
-						jshintConfig = fs.readJsonSync(process.cwd() + '/' + options.js.rulesFile);
-						jshintConfig.lookup = false;
-					}
+            if (options.js.rulesFile) {
+                jshintConfig = fs.readJsonSync(process.cwd() + '/' + options.js.rulesFile);
+                jshintConfig.lookup = false;
+            }
 
-					gulp.task(jsTask, function() {
-							jsReporter.openReporter(projectName, jsPath);
-							return gulp.src(jsSources)
-									.pipe(jshint(jshintConfig))
-									.pipe(jsReporter.reporter)
-									.on('end', jsReporter.closeReporter.bind(jsReporter));
-					});
-					tasks.push(jsTask);
-			}
+            gulp.task(jsTask, function () {
+                jsReporter.openReporter(projectName, jsPath);
+                return gulp.src(jsSources)
+                    .pipe(jshint(jshintConfig))
+                    .pipe(jsReporter.reporter)
+                    .on('end', jsReporter.closeReporter.bind(jsReporter));
+            });
+            tasks.push(jsTask);
+        }
 
-			if (options.eslint){
-				var eslint = require('gulp-eslint'),
-					eslintSources = options.eslint.src || options.eslint.sources || "src/**/*.js",
-					eslintPath = options.eslint.report || "reports/sonar/eslint-angular.json",
-					eslintTask = options.eslint.task || "ci-eslint",
-					eslintbase = options.eslint.base || "src",
-					eslintReporter = new this.ESReporter(eslintPath, eslintbase);
-					createReportPath(eslintTask);
+        if (options.eslint_angular) {
+            var eslint = require('gulp-eslint'),
+                eslintAngularSources = options.eslint_angular.src || options.eslint_angular.sources || "src/**/*.js",
+                eslintAngularPath = options.eslint_angular.report || "reports/sonar/eslint-angular.json",
+                eslintAngularTask = options.eslint_angular.task || "ci-eslint-angular",
+                eslintAngularBase = options.eslint_angular.base || "src",
+                eslintAngularReporter = new this.ESAngularReporter(eslintAngularPath, eslintAngularBase);
+            createReportPath(eslintAngularTask);
 
-					gulp.task(eslintTask, function() {
-							eslintReporter.openReporter(projectName, eslintPath);
-							return gulp.src(eslintSources)
-									.pipe(eslint({
-										reset: true,
-										configFile: options.eslint.rulesFile
-									}))
-									.pipe(eslint.format(eslintReporter.reporter));
-					});
-					tasks.push(eslintTask);
-			}
+            gulp.task(eslintAngularTask, function () {
+                eslintAngularReporter.openReporter(projectName, eslintAngularPath);
+                return gulp.src(eslintAngularSources)
+                    .pipe(eslint({
+                        reset: true,
+                        configFile: options.eslint_angular.rulesFile
+                    }))
+                    .pipe(eslint.format(eslintAngularReporter.reporter));
+            });
+            tasks.push(eslintAngularTask);
+        }
 
-			if (options.ts){
-				var tslint = require('gulp-tslint'),
-					tsSources = options.ts.src || options.ts.sources || "src/**/*.ts",
-					tsPath = options.ts.report || "reports/sonar/tslint.json",
-					tsTask = options.ts.task || "ci-tslint",
-					tsReporter = new this.TSLINTReporter(tsPath);
-					createReportPath(tsPath);
+        if (options.eslint) {
+            var eslint = require('gulp-eslint'),
+                eslintSources = options.eslint.src || options.eslint.sources || "src/**/*.js",
+                eslintPath = options.eslint.report || "reports/sonar/eslint.json",
+                eslintTask = options.eslint.task || "ci-eslint",
+                eslintBase = options.eslint.base || "src",
+                eslintReporter = new this.ESReporter(eslintPath, eslintBase);
+            createReportPath(eslintTask);
 
-					const testReporter = function (output, file, options) {
-					    console.log("Found " + output.length + " errors in " + file.path);
-					};
+            gulp.task(eslintTask, function () {
+                eslintReporter.openReporter(projectName, eslintPath);
+                return gulp.src(eslintSources)
+                    .pipe(eslint({
+                        reset: true,
+                        configFile: options.eslint.rulesFile
+                    }))
+                    .pipe(eslint.format(eslintReporter.reporter));
+            });
+            tasks.push(eslintTask);
+        }
 
-					gulp.task(tsTask, function() {
-							tsReporter.openReporter(projectName, tsPath);
-							return gulp.src(tsSources)
-									.pipe(tslint(options.ts.rulesFile))
-									.pipe(tslint.report(tsReporter.reporter, {
-							          emitError: false,
-						              sort: true,
-						              bell: true,
-						              fullPath: true
-						          	}))
-									.on('end', tsReporter.closeReporter.bind(tsReporter));
-					});
-					tasks.push(tsTask);
-			}
+        if (options.ts) {
+            var tslint = require('gulp-tslint'),
+                tsSources = options.ts.src || options.ts.sources || "src/**/*.ts",
+                tsPath = options.ts.report || "reports/sonar/tslint.json",
+                tsTask = options.ts.task || "ci-tslint",
+                tsReporter = new this.TSLINTReporter(tsPath);
+            createReportPath(tsPath);
 
-			if (options.callback) {
-				return run(tasks, options.callback);
-			} else {
-				return run(tasks);
-			}
-		}
+            const testReporter = function (output, file, options) {
+                console.log("Found " + output.length + " errors in " + file.path);
+            };
+
+            gulp.task(tsTask, function () {
+                tsReporter.openReporter(projectName, tsPath);
+                return gulp.src(tsSources)
+                    .pipe(tslint(options.ts.rulesFile))
+                    .pipe(tslint.report(tsReporter.reporter, {
+                        emitError: false,
+                        sort: true,
+                        bell: true,
+                        fullPath: true
+                    }))
+                    .on('end', tsReporter.closeReporter.bind(tsReporter));
+            });
+            tasks.push(tsTask);
+        }
+
+        if (options.callback) {
+            return run(tasks, options.callback);
+        } else {
+            return run(tasks);
+        }
+    }
 }
 
 module.exports = new SonarWebReporters();


### PR DESCRIPTION
- Non-angular ESLint reporter, fixing issue #5 
- Ability to send custom linter wrapper (e.g. `gulp-eslint`), to be able to run it from a custom version defined in project, handling issue #2

I'd try to make two different PR's, but when I commited the second it automatically merged into this one. Sorry about that.
